### PR TITLE
XAMEETINGS-58 : The invitation email is not sent.

### DIFF
--- a/src/main/resources/Meeting/MeetingSheet.xml
+++ b/src/main/resources/Meeting/MeetingSheet.xml
@@ -1,4 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
 
 <xwikidoc>
   <web>Meeting</web>
@@ -12,8 +31,8 @@
   <customClass/>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
   <creationDate>1356994800000</creationDate>
-  <date>1356994800000</date>
-  <contentUpdateDate>1356994800000</contentUpdateDate>
+  <date>1399998556000</date>
+  <contentUpdateDate>1399998512000</contentUpdateDate>
   <version>1.1</version>
   <title/>
   <defaultTemplate/>
@@ -69,7 +88,14 @@ $xwiki.ssx.use('Meeting.SkinExtension')
       #set($to = "$to $email,")
     #end
   #end
-  #set($defaultMail = $xwiki.getXWikiPreference('admin_email', 'mailer@xwiki.localdomain.com'))
+  #set($serverName = "$!request.serverName")
+  #set($curentUserName = $xwiki.getUserName($xcontext.user, false))
+  #if($serverName != '')
+    #set($sender = "$!{escapetool.xml($curentUserName)} &lt;no-reply@$!{serverName}&gt;")
+  #else
+    #set($sender = "$!{escapetool.xml($curentUserName)} &lt;no-reply@xwiki.localdomain.com&gt;")
+  #end
+  #set($defaultMail = $xwiki.getXWikiPreference('admin_email', "$sender"))
   #if($xwiki.mailsender.sendHtmlMessage("$defaultMail", $to, $xwiki.null, $xwiki.null, $title, "$message &lt;br&gt; &lt;a href=$link&gt; $msg.get('contrib.meeting.notification.link') &lt;/a&gt;", "", "")==0)
     $msg.get('contrib.meeting.notification.success')
   #else


### PR DESCRIPTION
XAMEETINGS-58 : The invitation email is not sent even when the email server is enabled
- The document name of the user was affected instead of the email of the sender 
