### PR TITLE
XAMEETINGS-69 : Move the current user to the top of the participants list

### DIFF
--- a/ui/src/main/resources/Meeting/MeetingClass.xml
+++ b/ui/src/main/resources/Meeting/MeetingClass.xml
@@ -266,7 +266,22 @@ $doc.save()
     </notes>
     <participants>
       <cache>0</cache>
-      <customDisplay/>
+      <customDisplay>{{velocity}}
+{{html}}
+#if($value.indexOf($xcontext.user) &gt; 0)
+  #set ($values = $value.split('\s*,\s*'))
+  #set ($participants = [$xcontext.user])
+  #foreach ($val in $values)
+    #if ($val.length() &gt; 0 &amp;&amp; $val != $xcontext.user)
+      #set ($discard = $participants.add($val))
+    #end
+  #end
+  #set ($value = $stringtool.join($participants, ','))
+#end
+##
+#template('displayer_users.vm')
+{{/html}}
+{{/velocity}}</customDisplay>
       <disabled>0</disabled>
       <displayType>input</displayType>
       <multiSelect>1</multiSelect>


### PR DESCRIPTION
This is implemented by making a custom displayer for the participants property so this feature is available everywhere not only on the meeting sheet.
