### PR TITLE
XAMEETINGS-87: In the AppBar use "Meetings" instead of "Meeting"

### DIFF
--- a/ui/src/main/resources/Meeting/MeetingTranslations.fr.xml
+++ b/ui/src/main/resources/Meeting/MeetingTranslations.fr.xml
@@ -47,7 +47,7 @@ Meeting.MeetingClass_status_value3=Annulé
 Meeting.MeetingClass_status_value4=Fini
 
 contrib.meeting.app.title=Réunions
-contrib.meeting.home.title=Réunion
+contrib.meeting.home.title=Réunions
 contrib.meeting.calendarView=Vue calendaire
 contrib.meeting.calendarView.title=Vue calendaire
 contrib.meeting.calendarView.noMacro.admin=Pour pouvoir avoir une vue calendaire des réunions, il faut installer la Macro FullCalendar sur ce Wiki :

--- a/ui/src/main/resources/Meeting/MeetingTranslations.fr.xml
+++ b/ui/src/main/resources/Meeting/MeetingTranslations.fr.xml
@@ -46,7 +46,8 @@ Meeting.MeetingClass_status_value2=Actif
 Meeting.MeetingClass_status_value3=Annulé
 Meeting.MeetingClass_status_value4=Fini
 
-contrib.meeting.application.title=Réunions
+contrib.meeting.app.title=Réunions
+contrib.meeting.home.title=Réunion
 contrib.meeting.calendarView=Vue calendaire
 contrib.meeting.calendarView.title=Vue calendaire
 contrib.meeting.calendarView.noMacro.admin=Pour pouvoir avoir une vue calendaire des réunions, il faut installer la Macro FullCalendar sur ce Wiki :

--- a/ui/src/main/resources/Meeting/MeetingTranslations.xml
+++ b/ui/src/main/resources/Meeting/MeetingTranslations.xml
@@ -46,7 +46,8 @@ Meeting.MeetingClass_status_value2=Active
 Meeting.MeetingClass_status_value3=Cancelled
 Meeting.MeetingClass_status_value4=Finished
 
-contrib.meeting.application.title=Meetings
+contrib.meeting.app.title=Meetings
+contrib.meeting.home.title=Meetings
 contrib.meeting.calendarView=Calendar View
 contrib.meeting.calendarView.title=Calendar View
 contrib.meeting.calendarView.noMacro.admin=To display the calendar view of the meetings, you need to install the Full Calendar Macro on this wiki :

--- a/ui/src/main/resources/Meeting/WebHome.xml
+++ b/ui/src/main/resources/Meeting/WebHome.xml
@@ -34,7 +34,7 @@
   <date>1386767586000</date>
   <contentUpdateDate>1386767586000</contentUpdateDate>
   <version>1.1</version>
-  <title>$services.localization.render('platform.appwithinminutes.appHomePageTitle', $doc.space)</title>
+  <title>$services.localization.render('contrib.meeting.home.title')</title>
   <comment/>
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.0</syntaxId>
@@ -244,7 +244,7 @@
       <name>platform.panels.MeetingApplication</name>
     </property>
     <property>
-      <parameters>label=Meeting
+      <parameters>label=$services.localization.render('contrib.meeting.app.title')
 target=Meeting.WebHome
 icon=icon:calendar</parameters>
     </property>


### PR DESCRIPTION
* Also fixes XAMEETINGS-88: Remove the word 'home' from homepage title and XAMEETINGS-85: Create french translation for the entry in app panel and the title from homepage