### PR TITLE
XAMEETINGS-114:Increase the top spacing for Description and Meetings …

### DIFF
--- a/ui/src/main/resources/Meeting/MeetingSheet.xml
+++ b/ui/src/main/resources/Meeting/MeetingSheet.xml
@@ -238,11 +238,11 @@ $xwiki.jsx.use('Meeting.MeetingSheet')
         (% class="col-sm-12 col-xs-12" %)
         (((
           #if($xcontext.action=="view" &amp;&amp; $doc.getValue('displayMap') == 1 &amp;&amp; "${doc.getValue('place')}"!="")
-            ((({{map location="$doc.getValue('place')" width="500" height="300" errors="hide"}}$doc.display('place'){{/map}})))
+            ((({{map location="$doc.getValue('place')" width="500" height="300" errors="hide"}}$doc.display('place'){{/map}})))&lt;br/&gt;
           #end
           #if (("$!doc.getValue('description').trim()" != '') &amp;&amp; ($xcontext.action=="view"))
             ; &lt;label for="Meeting.MeetingClass_0_description"&gt;#if($services.icon)$services.icon.render('application_view_list') #end     $services.localization.render('contrib.meeting.field.description')&lt;/label&gt;
-            : $doc.getValue('description')
+            : $doc.display('description')
           #end
           #if ($xcontext.action=="edit")
             ; &lt;label for="Meeting.MeetingClass_0_description"&gt;#if($services.icon)$services.icon.render('application_view_list') #end     $services.localization.render('contrib.meeting.field.description')&lt;/label&gt;##
@@ -251,7 +251,7 @@ $xwiki.jsx.use('Meeting.MeetingSheet')
           #end
           #if (("$!doc.getValue('notes').trim()" != '') &amp;&amp; ($xcontext.action=="view"))
             ; &lt;label for="Meeting.MeetingClass_0_notes"&gt;#if($services.icon)$services.icon.render('application_view_list') #end $services.localization.render('contrib.meeting.field.notes')&lt;/label&gt;
-            : $doc.getValue('notes')
+            : $doc.display('notes')
           #end
           #if ($xcontext.action=="edit")
             ; &lt;label for="Meeting.MeetingClass_0_notes"&gt;#if($services.icon)$services.icon.render('application_view_list') #end $services.localization.render('contrib.meeting.field.notes')&lt;/label&gt;##

--- a/ui/src/main/resources/Meeting/SkinExtension.xml
+++ b/ui/src/main/resources/Meeting/SkinExtension.xml
@@ -133,6 +133,9 @@
 
 #durationEdit select{
    width:auto ;
+}
+.col-sm-12.col-xs-12 label {
+  padding-top: 12px;
 }</code>
     </property>
     <property>

--- a/ui/src/main/resources/Meeting/SkinExtension.xml
+++ b/ui/src/main/resources/Meeting/SkinExtension.xml
@@ -133,9 +133,6 @@
 
 #durationEdit select{
    width:auto ;
-}
-.col-sm-12.col-xs-12 label {
-  padding-top: 12px;
 }</code>
     </property>
     <property>


### PR DESCRIPTION
Added a 12px padding-top for all the labels that might follow the rules of "Description" and "Meeting Notes", so if at any point another will be added, it will have the same 12px padding.