### PR TITLE
XAMEETINGS-149: All meetings have the start date set to 07/07/2016 15:45

### DIFF
--- a/ui/src/main/resources/Meeting/Code/MeetingClass.xml
+++ b/ui/src/main/resources/Meeting/Code/MeetingClass.xml
@@ -373,7 +373,7 @@ $durationString
       <customDisplay/>
       <dateFormat>dd/MM/yyyy HH:mm</dateFormat>
       <disabled>0</disabled>
-      <emptyIsToday>1</emptyIsToday>
+      <emptyIsToday>0</emptyIsToday>
       <name>startDate</name>
       <number>2</number>
       <picker>1</picker>

--- a/ui/src/main/resources/Meeting/Code/MeetingSheet.xml
+++ b/ui/src/main/resources/Meeting/Code/MeetingSheet.xml
@@ -389,6 +389,10 @@ if(displayMap) {
   (((
     (% class="col-xs-12 col-sm-4" %)
     (((
+    ## Set the current date as start date if the page is not MeetingTemplate
+    #if ("$!doc.getValue('startDate')" == '' &amp;&amp; $doc.getFullName() != 'Meeting.Code.MeetingTemplate')
+      #set ($discard = $doc.set('startDate', $datetool.date))
+    #end
     ; &lt;label for="Meeting.Code.MeetingClass_0_startDate"&gt;$!services.icon.render('calendar') $services.localization.render('contrib.meeting.field.startDate')&lt;/label&gt;##
       (% class="xHint" %)$services.localization.render('')
     : $doc.display('startDate')


### PR DESCRIPTION
https://jira.xwiki.org/projects/XAMEETINGS/issues/XAMEETINGS-149

This prevents the MeetingClass's `startDate` property to automatically set the current date if the field is empty.
Conversely, the `startDate` is set as the current date if the page is not the MeetingTemplate.